### PR TITLE
Change pre-commit order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,58 +1,68 @@
 # Pre-commit configuration file
 # Documentation: https://pre-commit.com/
 
-repos:
-  # Keep pre-commit itself up to date
--   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
-    hooks:
-    -   id: pre-commit-update
-        args: ["--verbose"]
+# Pre-commit configuration file
+# Documentation: https://pre-commit.com/
 
-  # Ruff for linting Python files
--   repo: https://github.com/charliermarsh/ruff-pre-commit
+repos:
+  # Basic file checks first (fast and foundational)
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml # Validate YAML files
+      - id: check-json # Validate JSON files
+      - id: check-merge-conflict # Prevent committing merge conflict markers
+      - id: check-added-large-files # Warn about large files being added
+        args: ["--maxkb=102400"]
+
+  # Format TOML files early (before other tools might read config)
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
+    hooks:
+      - id: toml-sort
+        args: ["--in-place"]
+
+  # Python syntax upgrades (should run before linting/formatting)
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.20.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py311-plus"]
+
+  # Import sorting (should run before Ruff to avoid conflicts)
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+
+  # Ruff for linting and formatting Python files
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.12.12
     hooks:
-    -   id: ruff-check
+      - id: ruff-check
         args: ["--fix"]
+      - id: ruff-format  # Add Ruff formatter
 
-    # nbQA to run Ruff on Jupyter Notebooks
--   repo: https://github.com/nbQA-dev/nbQA
+  # nbQA to run Ruff on Jupyter Notebooks (after Python tools)
+  - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.9.1
     hooks:
-    -   id: nbqa-ruff
+      - id: nbqa-ruff
         name: nbQA-Ruff
         args: ["--fix"]
         additional_dependencies: ["ruff"]
 
-    # Format and sort TOML files
--   repo: https://github.com/pappasam/toml-sort
-    rev: v0.24.2
-    hooks:
-    -   id: toml-sort
-        args: ["--in-place"]
-
-    # Sort imports in Python files (if separate from Ruff)
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-    -   id: isort
-        args: ["--profile", "black"]
-
-    # Pyupgrade for updating Python syntax to newer versions
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
-    hooks:
-    -   id: pyupgrade
-        args: ["--py311-plus"]
-
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  # Final cleanup (whitespace and newlines)
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    -   id: check-yaml # Validate YAML files
-    -   id: check-json # Validate JSON files
-    -   id: end-of-file-fixer # Ensure files end with a newline
-    -   id: trailing-whitespace # Remove trailing whitespace
-    -   id: check-merge-conflict # Prevent committing merge conflict markers
-    -   id: check-added-large-files # Warn about large files being added
-        args: ["--maxkb=102400"]
+      - id: end-of-file-fixer # Ensure files end with a newline
+      - id: trailing-whitespace # Remove trailing whitespace
+
+  # Keep pre-commit itself up to date (run last)
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.8.0
+    hooks:
+      - id: pre-commit-update
+        args: ["--verbose"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,63 +6,69 @@
 
 repos:
   # Basic file checks first (fast and foundational)
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      - id: check-yaml # Validate YAML files
-      - id: check-json # Validate JSON files
-      - id: check-merge-conflict # Prevent committing merge conflict markers
-      - id: check-added-large-files # Warn about large files being added
+    -   id: check-yaml # Validate YAML files
+    -   id: check-json # Validate JSON files
+    -   id: check-merge-conflict # Prevent committing merge conflict markers
+    -   id: check-added-large-files # Warn about large files being added
         args: ["--maxkb=102400"]
 
   # Format TOML files early (before other tools might read config)
-  - repo: https://github.com/pappasam/toml-sort
+-   repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2
     hooks:
-      - id: toml-sort
+    -   id: toml-sort
         args: ["--in-place"]
 
   # Python syntax upgrades (should run before linting/formatting)
-  - repo: https://github.com/asottile/pyupgrade
+-   repo: https://github.com/asottile/pyupgrade
     rev: v3.20.0
     hooks:
-      - id: pyupgrade
+    -   id: pyupgrade
         args: ["--py311-plus"]
 
   # Import sorting (should run before Ruff to avoid conflicts)
-  - repo: https://github.com/pre-commit/mirrors-isort
+-   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:
-      - id: isort
+    -   id: isort
         args: ["--profile", "black"]
 
   # Ruff for linting and formatting Python files
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.12.12
     hooks:
-      - id: ruff-check
+    -   id: ruff-check
         args: ["--fix"]
-      - id: ruff-format  # Add Ruff formatter
+    -   id: ruff-format  # Add Ruff formatter
 
   # nbQA to run Ruff on Jupyter Notebooks (after Python tools)
-  - repo: https://github.com/nbQA-dev/nbQA
+-   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.9.1
     hooks:
-      - id: nbqa-ruff
+    -   id: nbqa-ruff
         name: nbQA-Ruff
         args: ["--fix"]
         additional_dependencies: ["ruff"]
 
+  # checks for shell scripts
+-   repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.11.0
+    hooks:
+    -   id: shellcheck
+
   # Final cleanup (whitespace and newlines)
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      - id: end-of-file-fixer # Ensure files end with a newline
-      - id: trailing-whitespace # Remove trailing whitespace
+    -   id: end-of-file-fixer # Ensure files end with a newline
+    -   id: trailing-whitespace # Remove trailing whitespace
 
   # Keep pre-commit itself up to date (run last)
-  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.8.0
     hooks:
-      - id: pre-commit-update
+    -   id: pre-commit-update
         args: ["--verbose"]


### PR DESCRIPTION
This PR updates the execution order of the hooks. The previous order caused conflicts when updating notebooks, often requiring manual changes and multiple reruns before committing.